### PR TITLE
throw when configs are broken 

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var merge = require('lodash.merge');
 var path = require('path');
 var env = argv.env || process.env.NODE_ENV;
 
-var envConfigPath, defaultConfigPath, cfgDir,
-  defaultConfig, envConfig;
+var envConfigPath, defaultConfigPath, cfgDir, defaultConfig;
+var envConfig = {};
 
 // figure out where the config files are at
 cfgDir = process.env.NODE_CONFIG_DIR;
@@ -15,7 +15,6 @@ if (!cfgDir) {
 } else {
   cfgDir = path.resolve(cfgDir) + '/';
 }
-
 
 var defaultConfigPath = path.join(cfgDir, 'default');
 
@@ -32,11 +31,9 @@ try {
 try {
   if (envConfigPath) {
     envConfig = require(envConfigPath);
-  } else {
-    envConfig = {};
   }
 } catch (err) {
-  envConfig = {}; // no env specified
+  throw new Error(err);
 }
 
 module.exports = merge(defaultConfig, envConfig);

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "engines": {
     "node": ">= 0.10"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "index.js"
+  ]
 }

--- a/test/config/error.json
+++ b/test/config/error.json
@@ -1,0 +1,3 @@
+{
+  invalid: "json"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -47,4 +47,16 @@ describe('app-config-chain', function() {
     });
     done();
   });
+  it('should load env when provided', function(done) {
+    process.env.NODE_CONFIG_DIR = path.join(__dirname, 'config');
+    process.env.NODE_ENV = 'error';
+    try {
+      var config = require('../');
+    }
+    catch (e) {
+      should.exist(e);
+      should(e.message).match(/SyntaxError: /);
+      done();
+    }
+  });
 });


### PR DESCRIPTION
- add files array to pkg
- require errors are now thrown instead of absorbed.
  - a config file had an illegal token and would not get required, without any error.
- add test for broken config files
